### PR TITLE
fix issue when artifactory crashes

### DIFF
--- a/downloader_backend.py
+++ b/downloader_backend.py
@@ -496,7 +496,9 @@ class Downloader:
 
             if version not in artifacts_dict:
                 # extract real repo name in case it is cached
-                artifacts_dict[version] = art_path.joinpath(repo_name).stat().repo
+                if art_path.joinpath(repo_name).exists():
+                    # repo might be syncing (happens on new release addition)
+                    artifacts_dict[version] = art_path.joinpath(repo_name).stat().repo
 
         try:
             repo = artifacts_dict[self.settings.version]


### PR DESCRIPTION
```
31.03.2022 17:28:05 (ERROR) Traceback (most recent call last):
  File "downloader_backend.py", line 311, in run
  File "downloader_backend.py", line 92, in f_retry
  File "downloader_backend.py", line 499, in get_build_link
  File "artifactory.py", line 1579, in stat
  File "artifactory.py", line 862, in stat
  File "artifactory.py", line 851, in get_stat_json
FileNotFoundError: [Errno 2] No such file or directory: http://ottvmartifact.win.ansys.com:8080/artifactory/api/storage/v231_EBU_Certified
```